### PR TITLE
Proposal to change devRant online indicator color to green

### DIFF
--- a/src/themes/devRant.js
+++ b/src/themes/devRant.js
@@ -2,7 +2,7 @@ export default {
     name: 'devRant',
     thumbnailUrl: 'devRant.png',
     type: 'dark',
-    theme: {'sidebarBg':'#383952','sidebarText':'#ffffff','sidebarUnreadText':'#ffffff','sidebarTextHoverBg':'#f99a66','sidebarTextActiveBorder':'#f99a66','sidebarTextActiveColor':'#ffffff','sidebarHeaderBg':'#54556e','sidebarHeaderTextColor':'#ffffff','onlineIndicator':'#c14857','awayIndicator':'#e0b333','dndIndicator':'#f74343','mentionBj':'#c14857','mentionColor':'#ffffff','centerChannelBg':'#54556e','centerChannelColor':'#ffffff','newMessageSeparator':'#f80','linkColor':'#aaaab8','buttonBg':'#26a970','buttonColor':'#ffffff','errorTextColor':'#fd5960','mentionHighlightBg':'#c14857','mentionHighlightLink':'#e0b333','codeTheme':'solarized-dark','mentionBg':'#c14857'}
+    theme: {'sidebarBg':'#383952','sidebarText':'#ffffff','sidebarUnreadText':'#ffffff','sidebarTextHoverBg':'#f99a66','sidebarTextActiveBorder':'#f99a66','sidebarTextActiveColor':'#ffffff','sidebarHeaderBg':'#54556e','sidebarHeaderTextColor':'#ffffff','onlineIndicator':'#48c14a','awayIndicator':'#e0b333','dndIndicator':'#f74343','mentionBj':'#c14857','mentionColor':'#ffffff','centerChannelBg':'#54556e','centerChannelColor':'#ffffff','newMessageSeparator':'#f80','linkColor':'#aaaab8','buttonBg':'#26a970','buttonColor':'#ffffff','errorTextColor':'#fd5960','mentionHighlightBg':'#c14857','mentionHighlightLink':'#e0b333','codeTheme':'solarized-dark','mentionBg':'#c14857'}
 }
 
 


### PR DESCRIPTION
The red for online indicator made me think everyone was set to "Do not disturb" status.

Here's what it looks like with the green:
<img width="770" alt="Screen Shot 2019-10-04 at 12 38 37" src="https://user-images.githubusercontent.com/2672098/66224505-fa9a8880-e6a3-11e9-963b-dac339ecb800.png">
