### PR TITLE
Separating deploy and test actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,30 +6,11 @@ on:
     - master
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Run tests and check styling
-      run: |
-        npm install
-        npm test
-        npm run check
-      env:
-        CI: true
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@master
-
     - name: Build and Deploy
       uses: JamesIves/github-pages-deploy-action@master
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run tests
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   run_jest:
@@ -11,8 +11,9 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
+    - name: Check out branch
+      uses: actions/checkout@v1
     - name: Run Jest Tests
-    - uses: actions/checkout@v1
       uses: stefanoeb/jest-action@1.0.0
       env:
         CI: true
@@ -23,8 +24,9 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
+    - name: Check out branch
+      uses: actions/checkout@v1
     - name: Run ESlint Tests
-    - uses: actions/checkout@v1
       uses: gimenete/eslint-action@1.0
       env:
         CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Run tests
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  run_jest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - name: Run Jest Tests
+    - uses: actions/checkout@v1
+      uses: stefanoeb/jest-action@1.0.0
+      env:
+        CI: true
+
+  run_eslint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - name: Run ESlint Tests
+    - uses: actions/checkout@v1
+      uses: gimenete/eslint-action@1.0
+      env:
+        CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,4 @@ jobs:
     - name: Install dependencies
       run: npm install
     - name: Run ESlint Tests
-      uses: gimenete/eslint-action@1.0
-      env:
-        CI: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npm run check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,14 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-    - name: Check out branch
-      uses: actions/checkout@v1
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm install
     - name: Run Jest Tests
-      uses: stefanoeb/jest-action@1.0.0
+      run: npm test
       env:
         CI: true
 
@@ -24,8 +28,12 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-    - name: Check out branch
-      uses: actions/checkout@v1
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm install
     - name: Run ESlint Tests
       uses: gimenete/eslint-action@1.0
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,4 @@ jobs:
       uses: gimenete/eslint-action@1.0
       env:
         CI: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changed GitHub Actions to hopefully:
- Run Jest tests and ESlint checks when PRs are submitted
- Automatically deploy to gh-pages after a PR is merged (already existing functionality)