### PR TITLE
Proposal: Update Mattermost "Code Style" with one of the code theme options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This website was created by @avasconcelos114 and @josephk96 for the 2019 Hacktoberfest. We wanted to create an open-source project that would enable Mattermost users to easily copy and paste themes to use.
 
-## Code Style
+## Code Block Style
 
 Mattermost Themes follow the supported code styles in Mattermost - one of GitHub Theme, Solarized Dark Theme, Solarized Light Theme and Monokai Theme: https://docs.mattermost.com/help/messaging/formatting-text.html#code-block
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ This website was created by @avasconcelos114 and @josephk96 for the 2019 Hacktob
 
 ## Code Style
 
-Mattermost Themes follows the official Mattermost style guide, which you can read more about by clicking the link below:  
-https://docs.mattermost.com/developer/style-guide.html
+Mattermost Themes follow the supported code styles in Mattermost - one of GitHub Theme, Solarized Dark Theme, Solarized Light Theme and Monokai Theme: https://docs.mattermost.com/help/messaging/formatting-text.html#code-block
 
 ## Tech Stack
 


### PR DESCRIPTION
Currently in the README, Mattermost style guide is referenced in the "Code Style" section.

This style guide was in fact out of date and recently removed.

An option is to replace this link with one to code theme options at https://docs.mattermost.com/help/messaging/formatting-text.html#code-block instead.

![image](https://user-images.githubusercontent.com/13119842/81840817-7ea8ce80-9517-11ea-858c-69912f096a2e.png)

Let me know if that proposal works for you @avasconcelos114?